### PR TITLE
Disable lazy loading on sword if the browser is firefox.

### DIFF
--- a/src/lib/helpers/mobileDetect.js
+++ b/src/lib/helpers/mobileDetect.js
@@ -49,3 +49,10 @@ export const isSafari = () => {
 	const isSafariBrowser = safariAgent || iosDevice;
 	return isSafariBrowser;
 };
+
+export const isFirefox = () => {
+	const winNav = window.navigator;
+	const userAgent = winNav.userAgent;
+	const isFirefox = userAgent.indexOf('Firefox') > -1;
+	return isFirefox;
+}

--- a/src/routes/_inventory/_inventory-item.svelte
+++ b/src/routes/_inventory/_inventory-item.svelte
@@ -2,6 +2,7 @@
 	import { getContext } from 'svelte';
 	import { assets } from '$lib/store/app-stores';
 	import { lazyLoad } from '$lib/helpers/lazyload';
+	import { isFirefox } from '$lib/helpers/mobileDetect';
 
 	export let noStars = false;
 	export let itemdata = {};
@@ -57,6 +58,14 @@
 				/>
 			{/key}
 			<span class="gi-{vision} {vision} icon-gradient element" />
+		{:else if weaponType === 'sword' && isFirefox()}
+			<img
+				crossorigin="anonymous"
+				src={$assets[name]}
+				alt={localName}
+				class={weaponType}
+				on:error={(e) => e.target.remove()}
+			/>
 		{:else}
 			<img
 				loading="lazy"


### PR DESCRIPTION
This fixes issue that prevent sword weapon images loading in inventory menu. This simply checks if the browser is firefox, and disables if the browser is firefox.